### PR TITLE
Refresh stored PIN after updates

### DIFF
--- a/PhotoQRLogger/AuthManager.swift
+++ b/PhotoQRLogger/AuthManager.swift
@@ -8,7 +8,7 @@ class AuthManager: ObservableObject {
     @Published var showPinPrompt = false
     @Published var enteredPin = ""
 
-    private let correctPin = UserDefaults.standard.string(forKey: "userPIN") ?? "1234"
+    private var correctPin = UserDefaults.standard.string(forKey: "userPIN") ?? "1234"
 
     func authenticate() {
         let context = LAContext()
@@ -43,5 +43,6 @@ class AuthManager: ObservableObject {
 
     func saveNewPin(_ pin: String) {
         UserDefaults.standard.set(pin, forKey: "userPIN")
+        correctPin = UserDefaults.standard.string(forKey: "userPIN") ?? pin
     }
 }


### PR DESCRIPTION
## Summary
- Make `correctPin` mutable so it can update at runtime.
- Reload stored PIN from `UserDefaults` after saving a new value.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e9fe5388c833285519fd09317411d