### PR TITLE
Use scene-based retrieval for sharing

### DIFF
--- a/PhotoQRLogger/PhotoFullScreenView.swift
+++ b/PhotoQRLogger/PhotoFullScreenView.swift
@@ -61,7 +61,13 @@ struct PhotoFullScreenView: View {
     func share() {
         guard let img = image else { return }
         let activityVC = UIActivityViewController(activityItems: [img], applicationActivities: nil)
-        UIApplication.shared.windows.first?.rootViewController?.present(activityVC, animated: true)
+
+        if let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+           let rootVC = windowScene.windows.first?.rootViewController {
+            rootVC.present(activityVC, animated: true)
+        }
     }
 
     func delete() {


### PR DESCRIPTION
## Summary
- avoid deprecated window lookup by retrieving active `UIWindowScene` before presenting `UIActivityViewController`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688e9ff61b0c8332b23032958bc932f9