### PR TITLE
Load images asynchronously

### DIFF
--- a/PhotoQRLogger/PhotoFullScreenView.swift
+++ b/PhotoQRLogger/PhotoFullScreenView.swift
@@ -53,8 +53,14 @@ struct PhotoFullScreenView: View {
     }
 
     func loadImage() {
-        if let data = try? Data(contentsOf: imageURL) {
-            image = UIImage(data: data)
+        let url = imageURL
+        DispatchQueue.global(qos: .userInitiated).async {
+            if let data = try? Data(contentsOf: url),
+               let img = UIImage(data: data) {
+                DispatchQueue.main.async {
+                    self.image = img
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid blocking UI by loading images on a background queue

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project PhotoQRLogger.xcodeproj -scheme PhotoQRLogger -destination 'platform=iOS Simulator,name=iPhone 15,OS 17.4'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e9ffb119c833288c28a1d191ea4db