### PR TITLE
Ensure hosted view tracks scroll view bounds

### DIFF
--- a/PhotoQRLogger/ZoomableScrollView.swift
+++ b/PhotoQRLogger/ZoomableScrollView.swift
@@ -15,14 +15,23 @@ struct ZoomableScrollView<Content: View>: UIViewRepresentable {
 
         let hosted = UIHostingController(rootView: content)
         hosted.view.translatesAutoresizingMaskIntoConstraints = true
-        hosted.view.frame = CGRect(origin: .zero, size: CGSize(width: 300, height: 300))
+        hosted.view.frame = scrollView.bounds
 
         scrollView.addSubview(hosted.view)
+        scrollView.contentSize = hosted.view.bounds.size
         context.coordinator.hostingController = hosted
         return scrollView
     }
 
-    func updateUIView(_ scrollView: UIScrollView, context: Context) {}
+    func updateUIView(_ scrollView: UIScrollView, context: Context) {
+        if let hostedView = context.coordinator.hostingController?.view {
+            if hostedView.frame != scrollView.bounds {
+                hostedView.frame = scrollView.bounds
+            }
+            scrollView.contentSize = hostedView.bounds.size
+        }
+        context.coordinator.hostingController?.rootView = content
+    }
 
     func makeCoordinator() -> Coordinator {
         Coordinator()


### PR DESCRIPTION
## Summary
- Match the hosted view's frame to the scroll view's bounds
- Update the hosted view's frame and content size whenever the scroll view changes

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688ea0025bdc8332b8f51b13cfc9db91