### PR TITLE
Use AuthManager in PIN tests

### DIFF
--- a/Tests/PINTests.swift
+++ b/Tests/PINTests.swift
@@ -3,9 +3,20 @@ import XCTest
 
 final class PINTests: XCTestCase {
     func testPINStorageAndValidation() {
-        let pinManager = PINManager()
-        pinManager.setPIN("1234")
-        XCTAssertTrue(pinManager.validatePIN("1234"))
-        XCTAssertFalse(pinManager.validatePIN("0000"))
+        // Ensure a clean state
+        UserDefaults.standard.removeObject(forKey: "userPIN")
+
+        let authManager = AuthManager()
+        authManager.saveNewPin("1234")
+
+        authManager.enteredPin = "1234"
+        authManager.checkPIN()
+        XCTAssertTrue(authManager.isUnlocked)
+
+        authManager.isUnlocked = false
+        authManager.enteredPin = "0000"
+        authManager.checkPIN()
+        XCTAssertFalse(authManager.isUnlocked)
+        XCTAssertEqual(authManager.authError, "Incorrect PIN. Try again.")
     }
 }


### PR DESCRIPTION
## Summary
- replace non-existent `PINManager` with `AuthManager` in PIN unit test
- validate both correct and incorrect PIN scenarios via `AuthManager`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ea0057d508332aa5fb9985e6f0278