### PR TITLE
Ensure PDF context ends when graphics context is missing

### DIFF
--- a/PhotoQRLogger/PDFExporter.swift
+++ b/PhotoQRLogger/PDFExporter.swift
@@ -22,7 +22,10 @@ class PDFExporter {
         UIGraphicsBeginPDFContextToFile(outputURL.path, .zero, pdfMeta as [String : Any])
         UIGraphicsBeginPDFPage()
 
-        guard let context = UIGraphicsGetCurrentContext() else { return }
+        guard UIGraphicsGetCurrentContext() != nil else {
+            UIGraphicsEndPDFContext()
+            return
+        }
 
         let pageWidth = 595.2
         let pageHeight = 841.8


### PR DESCRIPTION
## Summary
- Close PDF context if `UIGraphicsGetCurrentContext()` returns nil in `PDFExporter.createPDF`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ea01148f083328c37a29833e51340