### PR TITLE
Validate PIN format

### DIFF
--- a/PhotoQRLogger/AuthManager.swift
+++ b/PhotoQRLogger/AuthManager.swift
@@ -36,13 +36,20 @@ class AuthManager: ObservableObject {
     func checkPIN() {
         if enteredPin == correctPin {
             isUnlocked = true
+            authError = nil
         } else {
             authError = "Incorrect PIN. Try again."
         }
     }
 
     func saveNewPin(_ pin: String) {
-        UserDefaults.standard.set(pin, forKey: "userPIN")
-        correctPin = UserDefaults.standard.string(forKey: "userPIN") ?? pin
+        let isValid = pin.count == 4 && pin.allSatisfy { $0.isNumber }
+        if isValid {
+            UserDefaults.standard.set(pin, forKey: "userPIN")
+            correctPin = pin
+            authError = nil
+        } else {
+            authError = "PIN must be 4 numeric digits."
+        }
     }
 }

--- a/Tests/PINTests.swift
+++ b/Tests/PINTests.swift
@@ -19,4 +19,14 @@ final class PINTests: XCTestCase {
         XCTAssertFalse(authManager.isUnlocked)
         XCTAssertEqual(authManager.authError, "Incorrect PIN. Try again.")
     }
+
+    func testInvalidPINRejected() {
+        UserDefaults.standard.removeObject(forKey: "userPIN")
+
+        let authManager = AuthManager()
+        authManager.saveNewPin("12ab")
+
+        XCTAssertNil(UserDefaults.standard.string(forKey: "userPIN"))
+        XCTAssertEqual(authManager.authError, "PIN must be 4 numeric digits.")
+    }
 }


### PR DESCRIPTION
## Summary
- ensure AuthManager validates PINs are 4 numeric digits and clears previous errors
- add unit test covering invalid PIN persistence

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688ea3c8809083329a664323e24ec42e