### PR TITLE
Use Keychain for PIN storage and improve auth errors

### DIFF
--- a/PhotoQRLogger/AuthManager.swift
+++ b/PhotoQRLogger/AuthManager.swift
@@ -8,7 +8,9 @@ class AuthManager: ObservableObject {
     @Published var showPinPrompt = false
     @Published var enteredPin = ""
 
-    private var correctPin = UserDefaults.standard.string(forKey: "userPIN") ?? "1234"
+    private var correctPin: String {
+        KeychainHelper.load(key: "userPIN") ?? "1234"
+    }
 
     func authenticate() {
         let context = LAContext()
@@ -22,12 +24,14 @@ class AuthManager: ObservableObject {
                     if success {
                         self.isUnlocked = true
                     } else {
+                        self.authError = err?.localizedDescription
                         self.showPinPrompt = true
                     }
                 }
             }
         } else {
             DispatchQueue.main.async {
+                self.authError = error?.localizedDescription
                 self.showPinPrompt = true
             }
         }
@@ -37,6 +41,7 @@ class AuthManager: ObservableObject {
         if enteredPin == correctPin {
             isUnlocked = true
             authError = nil
+            enteredPin = ""
         } else {
             authError = "Incorrect PIN. Try again."
         }
@@ -45,8 +50,7 @@ class AuthManager: ObservableObject {
     func saveNewPin(_ pin: String) {
         let isValid = pin.count == 4 && pin.allSatisfy { $0.isNumber }
         if isValid {
-            UserDefaults.standard.set(pin, forKey: "userPIN")
-            correctPin = pin
+            KeychainHelper.save(pin, for: "userPIN")
             authError = nil
         } else {
             authError = "PIN must be 4 numeric digits."

--- a/PhotoQRLogger/KeychainHelper.swift
+++ b/PhotoQRLogger/KeychainHelper.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Security
+
+struct KeychainHelper {
+    @discardableResult
+    static func save(_ value: String, for key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    static func load(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+
+    static func delete(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Tests/PINTests.swift
+++ b/Tests/PINTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class PINTests: XCTestCase {
     func testPINStorageAndValidation() {
         // Ensure a clean state
-        UserDefaults.standard.removeObject(forKey: "userPIN")
+        KeychainHelper.delete(key: "userPIN")
 
         let authManager = AuthManager()
         authManager.saveNewPin("1234")
@@ -21,12 +21,12 @@ final class PINTests: XCTestCase {
     }
 
     func testInvalidPINRejected() {
-        UserDefaults.standard.removeObject(forKey: "userPIN")
+        KeychainHelper.delete(key: "userPIN")
 
         let authManager = AuthManager()
         authManager.saveNewPin("12ab")
 
-        XCTAssertNil(UserDefaults.standard.string(forKey: "userPIN"))
+        XCTAssertNil(KeychainHelper.load(key: "userPIN"))
         XCTAssertEqual(authManager.authError, "PIN must be 4 numeric digits.")
     }
 }


### PR DESCRIPTION
## Summary
- Store PIN values in iOS Keychain instead of UserDefaults
- Expose authentication errors and clear entered PIN after success
- Update PIN unit tests and add Keychain helper utility

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f0bbe969083328b91ee30e2cf8d87