### PR TITLE
Harden Keychain PIN storage and add package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.8
+import PackageDescription
+
+let package = Package(
+    name: "PhotoQRLogger",
+    platforms: [
+        .iOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "PhotoQRLogger",
+            targets: ["PhotoQRLogger"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "PhotoQRLogger",
+            path: "PhotoQRLogger"
+        ),
+        .testTarget(
+            name: "PhotoQRLoggerTests",
+            dependencies: ["PhotoQRLogger"],
+            path: "Tests"
+        )
+    ]
+)

--- a/PhotoQRLogger/KeychainHelper.swift
+++ b/PhotoQRLogger/KeychainHelper.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Security
+
+struct KeychainHelper {
+    private static let service = "com.photoqrlogger.pin"
+
+    @discardableResult
+    static func save(_ value: String, for key: String) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: service,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    static func load(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+
+    static func delete(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecAttrService as String: service
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Tests/PINTests.swift
+++ b/Tests/PINTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class PINTests: XCTestCase {
     func testPINStorageAndValidation() {
         // Ensure a clean state
-        UserDefaults.standard.removeObject(forKey: "userPIN")
+        KeychainHelper.delete(key: "userPIN")
 
         let authManager = AuthManager()
         authManager.saveNewPin("1234")
@@ -21,12 +21,22 @@ final class PINTests: XCTestCase {
     }
 
     func testInvalidPINRejected() {
-        UserDefaults.standard.removeObject(forKey: "userPIN")
+        KeychainHelper.delete(key: "userPIN")
 
         let authManager = AuthManager()
         authManager.saveNewPin("12ab")
 
-        XCTAssertNil(UserDefaults.standard.string(forKey: "userPIN"))
+        XCTAssertNil(KeychainHelper.load(key: "userPIN"))
         XCTAssertEqual(authManager.authError, "PIN must be 4 numeric digits.")
+    }
+
+    func testCheckPINWithNoStoredPIN() {
+        KeychainHelper.delete(key: "userPIN")
+
+        let authManager = AuthManager()
+        authManager.enteredPin = "1234"
+        authManager.checkPIN()
+        XCTAssertFalse(authManager.isUnlocked)
+        XCTAssertEqual(authManager.authError, "No PIN set.")
     }
 }


### PR DESCRIPTION
## Summary
- Remove fallback PIN and report when no PIN is stored
- Add Keychain service and access level, handle save failures
- Provide Swift Package manifest and extra PIN unit test

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_688f0bbe969083328b91ee30e2cf8d87